### PR TITLE
Add build_macos.sh

### DIFF
--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+mkdir -p build
+cd build/
+
+qmake PREFIX=/usr ../FFaudioConverter.pro -spec macx-clang CONFIG+=release
+make


### PR DESCRIPTION
This modifies build_linux.sh to be able to build on MacOS. After running, the packaged app can be found in the build/ directory.

I needed to make a tweak to get the app running - the ffmpeg binary needs to be set to /usr/local/bin/ffmpeg to pick up on the Homebrew ffmpeg - but otherwise the app works quite well.